### PR TITLE
Bad certificate error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://www.rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,52 @@
+PATH
+  remote: .
+  specs:
+    yadisk (0.0.1)
+
+GEM
+  remote: http://www.rubygems.org/
+  specs:
+    coveralls (0.8.23)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.16.1)
+      term-ansicolor (~> 1.3)
+      thor (>= 0.19.4, < 2.0)
+      tins (~> 1.6)
+    diff-lcs (1.3)
+    docile (1.3.2)
+    json (2.3.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.3)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.0.1)
+    tins (1.24.1)
+      sync
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  coveralls
+  rspec (~> 3.8.0, < 4.0)
+  yadisk!
+
+BUNDLED WITH
+   2.0.1

--- a/bin/yadisk
+++ b/bin/yadisk
@@ -6,10 +6,15 @@ require 'yadisk/check_runtime'
 
 Yadisk::CheckRuntime.check_wget
 
-if ARGV.length == 1
-  Yadisk::Main.new.download(ARGV[0])
-elsif ARGV.length == 2
-  Yadisk::Main.new.download(ARGV[0], folder: ARGV[1])
-else
-  puts "Use: $ yadisk url [/path/to/download/local/folder]\n"
+begin
+  if ARGV.length == 1
+    Yadisk::Main.new.download(ARGV[0])
+  elsif ARGV.length == 2
+    Yadisk::Main.new.download(ARGV[0], folder: ARGV[1])
+  else
+    puts "Use: $ yadisk url [/path/to/download/local/folder]\n"
+  end
+rescue OpenSSL::SSL::SSLError
+  puts 'SSL certificate error while accessing Yandex.'
+  exit(-1)
 end

--- a/lib/yadisk.rb
+++ b/lib/yadisk.rb
@@ -5,16 +5,15 @@ require 'cgi/util'
 require 'uri'
 require 'io/console'
 require 'json'
+require 'net/http'
 
 module Yadisk
   class Main
     BASE_URL = 'https://cloud-api.yandex.net:443/v1/disk/public/resources/download?public_key='
     def download(url, folder: './')
       enc_url = CGI::escape(url)
-
-      puts "wget -qO - #{BASE_URL}#{enc_url}"
-      res = IO.popen("wget -qO - #{BASE_URL}#{enc_url}").read
-      json_res = JSON.parse(res)
+      response = Net::HTTP.get(URI("#{BASE_URL}#{enc_url}"))
+      json_res = JSON.parse(response)
       download_url = json_res['href']
       filename = CGI::parse(URI(download_url).query)["filename"][0]
       folder = folder + "/" if not folder.end_with?('/')


### PR DESCRIPTION
Currently when bad certificate error happens `yadisk` invocation fails with `JSON::ParserError` error. Bad certificate error happen often if you invoke `yadisk` in a country where Yandex access is blocked (e.g. Ukraine). It would be nicer to inform the user about the real reason of failure because `JSON::ParserError` doesn't explain it.