### PR TITLE
Support passing custom options to wget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ build-iPhoneSimulator/
 *~
 # Ignore download test files
 # /spec/files/
+
+# IDE
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yadisk (0.0.1)
+    yadisk (0.0.2)
 
 GEM
   remote: http://www.rubygems.org/

--- a/bin/yadisk
+++ b/bin/yadisk
@@ -3,18 +3,37 @@
 
 require 'yadisk'
 require 'yadisk/check_runtime'
+require 'optparse'
 
 Yadisk::CheckRuntime.check_wget
 
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = 'Use: $ yadisk url [/path/to/download/local/folder]'
+  opts.separator ''
+  opts.separator 'Options:'
+  opts.on('-w', '--wget-options=OPTIONS', 'additional options passed to wget process') do |wget_options|
+    options[:wget_options] = wget_options
+  end
+end
+
 begin
-  if ARGV.length == 1
-    Yadisk::Main.new.download(ARGV[0])
-  elsif ARGV.length == 2
-    Yadisk::Main.new.download(ARGV[0], folder: ARGV[1])
+  parser.parse!
+
+  url = ARGV.shift
+
+  if url
+    folder = ARGV.shift
+    options[:folder] = folder if folder
+    Yadisk::Main.new.download(url, **options)
   else
-    puts "Use: $ yadisk url [/path/to/download/local/folder]\n"
+    puts parser.help
   end
 rescue OpenSSL::SSL::SSLError
   puts 'SSL certificate error while accessing Yandex.'
+  exit(-1)
+rescue OptionParser::ParseError => exception
+  puts "Error: #{exception}"
+  puts parser.help
   exit(-1)
 end

--- a/lib/yadisk.rb
+++ b/lib/yadisk.rb
@@ -10,7 +10,7 @@ require 'net/http'
 module Yadisk
   class Main
     BASE_URL = 'https://cloud-api.yandex.net:443/v1/disk/public/resources/download?public_key='
-    def download(url, folder: './')
+    def download(url, folder: './', wget_options: nil)
       enc_url = CGI::escape(url)
       response = Net::HTTP.get(URI("#{BASE_URL}#{enc_url}"))
       json_res = JSON.parse(response)
@@ -18,7 +18,7 @@ module Yadisk
       filename = CGI::parse(URI(download_url).query)["filename"][0]
       folder = folder + "/" if not folder.end_with?('/')
 
-      system("wget '#{download_url}' -O '#{folder}#{filename}'")
+      system("wget '#{download_url}' -O '#{folder}#{filename}' #{wget_options}")
     end
   end
 end


### PR DESCRIPTION
Allows to run download and pass custom options to wget, e.g.:
```
yadisk https://yadi.sk/i/HEjuI2Ln3RiRcQ -w -c
```
will pass `-c` switch to wget. This case is useful when downloading large files, because it won't truncate what's already downloaded if you have to restart the download.